### PR TITLE
transspell: use column instead of pr

### DIFF
--- a/spellcheck/transspell
+++ b/spellcheck/transspell
@@ -119,4 +119,4 @@ awk '
 -e "s/(%\([^)]+\).)+/ /g # Python 3-style %(named)s variables" \
 -e "s/(\{[^}]+)}+/ /g # {named} variables" \
 -e 's/[_&~]//g # ~Common _accelerator &keys' |
-hunspell -d "$LOCALE" -l | sort -u | pr -3at
+hunspell -d "$LOCALE" -l | sort -u | column


### PR DESCRIPTION
Don't know whether the use of exactly 3 columns was the intention, but here is a suggestion to something more flexible.

By using 'column' command-line tool, from util-linux, the number of lines printed are adjusted to the size of the terminal and the size of the words found. So, more than 3 columns may be printed, allowing shorter columns.